### PR TITLE
fix(connection): plan digest 改为对去 digest agreement 的确定性 CBOR 计算 SHA-256

### DIFF
--- a/docs/proposals/connection-wire.zh.md
+++ b/docs/proposals/connection-wire.zh.md
@@ -43,7 +43,17 @@ Raw、未认证 TCP 不是本 profile 的合规 carrier。TLS、SSH、QUIC 或�
 - text 必须是有效 UTF-8，不接受未配对 surrogate 的替代编码；
 - 未在当前 frame schema 中允许的字段导致 frame-invalid，`x-` 扩展字段除外。
 
-Plan digest 对规范化 agreement 去除 `digest` 字段后的 deterministic CBOR bytes 计算 SHA-256；计算结果再写入 `digest`。双方不能对包含 digest 自身的对象或各自语言对象的默认序列化结果计算 digest。
+### Plan digest projection and representation
+
+Plan digest 的输入必须是 Endpoint Connection 规范化后的完整 `ConnectionAgreement`，并在编码前执行以下投影：
+
+1. 必须移除顶层 `digest` 字段；
+2. host-language map/object 中表示字段缺席的 `undefined` 值属性必须被省略，不能编码为 CBOR undefined 或替换为 `null`；
+3. root、array element 或其他位置的 `undefined` 必须作为 `plan-invalid` 拒绝；
+4. byte string 必须按原始 bytes 编码，不能转成数字 array、base64 text 或 host object；
+5. 其余值必须满足本 profile 的 CBOR subset；尤其 integer 必须位于 `0..2^53-1`，负整数不能进入 plan digest。
+
+实现必须对投影后的 deterministic CBOR bytes 计算 SHA-256，并把结果表示为 `sha256:` 加 64 个小写十六进制字符。`digest` 因而必须匹配 `^sha256:[0-9a-f]{64}$`。双方不能对包含 digest 自身的对象、各自语言对象的默认序列化结果或不同的缺席值投影计算 digest。
 
 ### Byte-stream framing
 

--- a/docs/proposals/core.zh.md
+++ b/docs/proposals/core.zh.md
@@ -125,6 +125,8 @@ interface ApiReference {
 
 `apiVersion` 由协议 group 和版本组成，`kind` 标识该 group 中的协议。二者共同确定一份版本化协议。
 
+`kind` 必须（MUST）匹配 `^[A-Z][A-Za-z0-9]*$`：它以 ASCII 大写字母开头，后续只能包含 ASCII 字母或数字。空字符串、Unicode 字母、连字号和下划线均不是合法的 Core 协议 `kind`。Evaluator 必须（MUST）在注册 definition、解析声明或查询坐标时拒绝不符合该语法的引用。
+
 Core 可以解析版本标识并建立候选集合，但不假定同一 major 下的 alpha、beta 和 stable 必然互通。精确版本之外的兼容关系由该协议的 definition 声明。没有对应 definition 时，evaluator 不能声称已经完成该协议的协商。
 
 Core 不根据 group 名称判断协议是否属于某个标准集合。命名空间归属与保留规则、协议发布状态和目录收录规则由相应治理或分发机制规定，不属于协商算法。只要坐标、definition 和声明满足本协议，evaluator 对它们采用相同的校验与协商过程。

--- a/docs/proposals/endpoint-connection.zh.md
+++ b/docs/proposals/endpoint-connection.zh.md
@@ -337,7 +337,7 @@ Participant identity 不必包含 component 或 facet provenance。即使本地 
 - 选择哪个协议版本和功能子集；
 - agreement 中需要保存哪些协议专属参数。
 
-Connection 汇总协议结果，规范化排序并计算 plan digest。双方必须针对相同的 offer revision tuple 得到同一 digest，再分别接受该 plan。
+Connection 汇总协议结果，按本节规则规范化排序并计算 plan digest。双方必须针对相同的 offer revision tuple 得到同一 digest，再分别接受该 plan。
 
 ### Agreement and attachment
 
@@ -351,12 +351,24 @@ interface ConnectionAgreement {
   readonly revision: number
   readonly offers: readonly OfferRevision[]
   readonly digest: string
+  readonly compatible: boolean
   readonly protocols: readonly NegotiatedProtocol[]
+  readonly bindings: readonly CapabilityBinding[]
   readonly issues: readonly ConnectionIssue[]
 }
 ```
 
-`NegotiatedProtocol` 记录协议版本、参与者和由协议 definition 生成的 `spec`。Connection 不假定它一定是 consumer/provider binding。
+`NegotiatedProtocol` 记录协议版本、参与者和由协议 definition 生成的 `agreement`。Connection 不假定它一定是 consumer/provider binding。只有 capability-style agreement 产生顶层 `bindings`；该投影视图不改变 definition-owned agreement 的语义。
+
+Connection 必须在计算 digest 前执行以下规范化：
+
+- `offers` 必须严格包含 coordinator offer、responder offer，顺序不能交换；同一 offer 内的 declaration 顺序是该 offer 的一部分，双方必须原样保留；
+- `protocols` 必须按 `[apiVersion, kind]` 的 deterministic CBOR encoding 逐字节字典序排列；每项的 `participants` 与 `issues` 分别按其完整 deterministic CBOR encoding 排列；
+- capability binding 必须先移除尚未分配的 `bindingId`，按其余完整字段的 deterministic CBOR encoding 排列，再依次分配 `binding-1`、`binding-2`；
+- 顶层 `issues` 必须按每项完整 deterministic CBOR encoding 排列；
+- protocol definition 所有的 `agreement` 内部 array 不能由 Connection 通用重排；其顺序语义与确定性由该协议自己的规范和 conformance fixture 定义。
+
+这里的“排列”都表示比较完整 deterministic CBOR encoding 的逐字节无符号字典序，不使用 locale collation、注册顺序或 host object enumeration order。Plan digest 的字段投影、CBOR 数据模型和字符串表示由 Connection Wire Profile 规定。
 
 Plan 被双方接受后，每份 negotiated protocol 得到一个 connection-scoped attachment。Attachment 只向 agreement 中列出的本端 participant 签发，并在 plan 替换、连接关闭或 permission 撤销时失效。
 
@@ -394,7 +406,7 @@ Offer revision 在一个 endpoint view 的生命周期内单调递增。每个 r
 
 一个 connection 只有一个 negotiation coordinator。第一版由主动连接方担任，但双方独立复算 candidate plan：
 
-1. coordinator 选择双方确定 revision 的完整 offer；
+1. coordinator 选择双方确定 revision 的完整 offer，并把 offer revision tuple 固定为 `[coordinator, responder]`；
 2. 双方验证 offer 外壳和限制；
 3. 双方用同一组 protocol definitions 与显式 connection policy 计算 candidate；
 4. 双方比较 offer revision tuple、plan revision 与 digest；

--- a/packages/connection/CHANGELOG.md
+++ b/packages/connection/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes to `@dsh-std/connection` are recorded here.
 
 ## 0.1.1-rc.1
 
+- Plan digests now hash the digest-stripped agreement with SHA-256 over its deterministic CBOR encoding (RFC 8949 core deterministic subset), rendered as `sha256:` plus 64 lowercase hex digits, replacing the 32-bit FNV-1a hash of a JSON-ish canonical string that covered only part of the agreement. The encoder drops `undefined`-valued map properties (the agreement's JSON wire projection) and rejects every other `undefined`, non-integer or unsafe number, unpaired surrogate, and non-plain object instead of colliding.
+- Documented the `resolveConnection` offer order convention: `left` is the coordinator (initiator) offer and both parties must resolve with the offers in the same order for digests to compare equal.
 - Aligned the package with the workspace `0.1.1` prerelease line without changing the existing Connection protocol semantics.
 
 ## 0.1.0-rc1

--- a/packages/connection/CHANGELOG.md
+++ b/packages/connection/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 Changes to `@dsh-std/connection` are recorded here.
 
+## 0.1.1-rc.2
+
+- Plan digests now hash the digest-stripped agreement with SHA-256 over its deterministic CBOR encoding (RFC 8949 core deterministic subset), rendered as `sha256:` plus 64 lowercase hex digits, replacing the 32-bit FNV-1a hash of a JSON-ish canonical string that covered only part of the agreement.
+- Aligned digest input with the Connection Wire data model: byte strings retain their bytes, `undefined`-valued map properties are omitted as absent fields, and every other `undefined`, negative or unsafe integer, unpaired surrogate, cyclic value, and non-plain object is rejected instead of colliding or producing an out-of-profile plan.
+- Defined the `resolveConnection` offer order convention (`left` is coordinator), and normalized protocols, participants, bindings, and issues by deterministic-CBOR byte order so host locale collation cannot change binding IDs or plan digests.
+
 ## 0.1.1-rc.1
 
-- Plan digests now hash the digest-stripped agreement with SHA-256 over its deterministic CBOR encoding (RFC 8949 core deterministic subset), rendered as `sha256:` plus 64 lowercase hex digits, replacing the 32-bit FNV-1a hash of a JSON-ish canonical string that covered only part of the agreement. The encoder drops `undefined`-valued map properties (the agreement's JSON wire projection) and rejects every other `undefined`, non-integer or unsafe number, unpaired surrogate, and non-plain object instead of colliding.
-- Documented the `resolveConnection` offer order convention: `left` is the coordinator (initiator) offer and both parties must resolve with the offers in the same order for digests to compare equal.
-- Aligned the package with the workspace `0.1.1` prerelease line without changing the existing Connection protocol semantics.
+- Aligned the package with the workspace `0.1.1` prerelease line.
 
 ## 0.1.0-rc1
 

--- a/packages/connection/package.json
+++ b/packages/connection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsh-std/connection",
-  "version": "0.1.1-rc.1",
+  "version": "0.1.1-rc.2",
   "license": "MIT",
   "repository": { "type": "git", "url": "git+https://github.com/Yan-Zero/dsh-std.git", "directory": "packages/connection" },
   "publishConfig": { "access": "public" },

--- a/packages/connection/src/digest.ts
+++ b/packages/connection/src/digest.ts
@@ -13,9 +13,9 @@ const LONE_SURROGATE = /[\uD800-\uDFFF]/u
 
 /**
  * Computes the plan digest of an agreement without its `digest` field, as `sha256:` followed by
- * 64 lowercase hex digits. Protocol agreements inside the plan must consist of JSON-like data
- * (safe integers, well-formed strings, booleans, null, arrays, plain objects); anything else
- * throws a TypeError naming the offending path.
+ * 64 lowercase hex digits. Protocol agreements inside the plan must consist of the Connection
+ * Wire data model (non-negative safe integers, well-formed strings, byte strings, booleans, null,
+ * arrays, and plain objects); anything else throws a TypeError naming the offending path.
  */
 export function planDigest(agreement: Omit<ConnectionPlan, 'digest'>): string {
   return `sha256:${sha256Hex(deterministicCbor(agreement))}`
@@ -24,17 +24,22 @@ export function planDigest(agreement: Omit<ConnectionPlan, 'digest'>): string {
 /**
  * Encodes a value into the RFC 8949 Core Deterministic Encoding subset the wire profile pins:
  * shortest-form integers, definite lengths, and map keys sorted bytewise by their encodings.
- * Own map properties whose value is `undefined` are dropped before encoding — the same projection
- * `JSON.stringify` gives the agreement on a JSON wire. Every other `undefined`, non-integer or
- * unsafe number, unpaired surrogate, or non-plain object throws a TypeError instead of colliding.
+ * Own map properties whose value is `undefined` are dropped before encoding. Every other
+ * `undefined`, negative, non-integer or unsafe number, unpaired surrogate, cyclic value, or
+ * non-plain object throws a TypeError instead of producing an out-of-profile agreement.
  */
 export function deterministicCbor(value: unknown): Uint8Array {
   const bytes: number[] = []
-  encodeValue(value, bytes, '/')
+  encodeValue(value, bytes, '/', new Set<object>())
   return Uint8Array.from(bytes)
 }
 
-function encodeValue(value: unknown, bytes: number[], path: string): void {
+/** Orders values by the bytewise lexicographic order of their deterministic CBOR encodings. */
+export function compareDeterministicCbor(left: unknown, right: unknown): number {
+  return compareBytes(deterministicCbor(left), deterministicCbor(right))
+}
+
+function encodeValue(value: unknown, bytes: number[], path: string, ancestors: Set<object>): void {
   if (value === null) {
     bytes.push(0xf6)
     return
@@ -44,35 +49,49 @@ function encodeValue(value: unknown, bytes: number[], path: string): void {
     return
   }
   if (typeof value === 'number') {
-    if (!Number.isSafeInteger(value)) throw new TypeError(`plan digest input at ${path} must be a safe integer, got ${String(value)}`)
-    if (value >= 0) encodeHead(0, value, bytes)
-    else encodeHead(1, -1 - value, bytes)
+    if (!Number.isSafeInteger(value) || value < 0) throw new TypeError(`plan digest input at ${path} must be a non-negative safe integer, got ${String(value)}`)
+    encodeHead(0, value, bytes)
     return
   }
   if (typeof value === 'string') {
     encodeText(value, bytes, path)
     return
   }
+  if (value instanceof Uint8Array) {
+    encodeHead(2, value.byteLength, bytes)
+    for (const byte of value) bytes.push(byte)
+    return
+  }
   if (Array.isArray(value)) {
-    encodeHead(4, value.length, bytes)
-    for (const [index, element] of value.entries()) encodeValue(element, bytes, child(path, String(index)))
+    enter(value, path, ancestors)
+    try {
+      encodeHead(4, value.length, bytes)
+      for (const [index, element] of value.entries()) encodeValue(element, bytes, child(path, String(index)), ancestors)
+    } finally {
+      ancestors.delete(value)
+    }
     return
   }
   if (isPlainObject(value)) {
-    encodeMap(value, bytes, path)
+    enter(value, path, ancestors)
+    try {
+      encodeMap(value, bytes, path, ancestors)
+    } finally {
+      ancestors.delete(value)
+    }
     return
   }
-  throw new TypeError(`plan digest input at ${path} must be null, a boolean, a safe integer, a string, an array, or a plain object, got ${describe(value)}`)
+  throw new TypeError(`plan digest input at ${path} must be null, a boolean, a non-negative safe integer, a string, a byte string, an array, or a plain object, got ${describe(value)}`)
 }
 
-function encodeMap(value: Record<string, unknown>, bytes: number[], path: string): void {
+function encodeMap(value: Record<string, unknown>, bytes: number[], path: string, ancestors: Set<object>): void {
   const entries: { key: number[]; element: number[] }[] = []
   for (const [key, element] of Object.entries(value)) {
     if (element === undefined) continue
     const keyBytes: number[] = []
     encodeText(key, keyBytes, child(path, key))
     const elementBytes: number[] = []
-    encodeValue(element, elementBytes, child(path, key))
+    encodeValue(element, elementBytes, child(path, key), ancestors)
     entries.push({ key: keyBytes, element: elementBytes })
   }
   entries.sort((left, right) => compareBytes(left.key, right.key))
@@ -81,6 +100,11 @@ function encodeMap(value: Record<string, unknown>, bytes: number[], path: string
     for (const byte of entry.key) bytes.push(byte)
     for (const byte of entry.element) bytes.push(byte)
   }
+}
+
+function enter(value: object, path: string, ancestors: Set<object>): void {
+  if (ancestors.has(value)) throw new TypeError(`plan digest input at ${path} must not contain a cycle`)
+  ancestors.add(value)
 }
 
 function encodeText(value: string, bytes: number[], path: string): void {
@@ -107,7 +131,7 @@ function encodeHead(major: number, argument: number, bytes: number[]): void {
   }
 }
 
-function compareBytes(left: readonly number[], right: readonly number[]): number {
+function compareBytes(left: ArrayLike<number>, right: ArrayLike<number>): number {
   const length = Math.min(left.length, right.length)
   for (let index = 0; index < length; index += 1) {
     const delta = left[index]! - right[index]!

--- a/packages/connection/src/digest.ts
+++ b/packages/connection/src/digest.ts
@@ -1,0 +1,203 @@
+import type { ConnectionPlan } from './model.js'
+
+/**
+ * Plan digest per docs/proposals/connection-wire.zh.md: SHA-256 over the deterministic CBOR
+ * encoding of the digest-stripped agreement. Both connection parties recompute the digest
+ * independently from their own negotiation result and compare for equality before accepting a plan.
+ */
+
+const UTF8 = new TextEncoder()
+
+/** Matches only unpaired surrogates: under the `u` flag a well-formed pair is one astral code point. */
+const LONE_SURROGATE = /[\uD800-\uDFFF]/u
+
+/**
+ * Computes the plan digest of an agreement without its `digest` field, as `sha256:` followed by
+ * 64 lowercase hex digits. Protocol agreements inside the plan must consist of JSON-like data
+ * (safe integers, well-formed strings, booleans, null, arrays, plain objects); anything else
+ * throws a TypeError naming the offending path.
+ */
+export function planDigest(agreement: Omit<ConnectionPlan, 'digest'>): string {
+  return `sha256:${sha256Hex(deterministicCbor(agreement))}`
+}
+
+/**
+ * Encodes a value into the RFC 8949 Core Deterministic Encoding subset the wire profile pins:
+ * shortest-form integers, definite lengths, and map keys sorted bytewise by their encodings.
+ * Own map properties whose value is `undefined` are dropped before encoding — the same projection
+ * `JSON.stringify` gives the agreement on a JSON wire. Every other `undefined`, non-integer or
+ * unsafe number, unpaired surrogate, or non-plain object throws a TypeError instead of colliding.
+ */
+export function deterministicCbor(value: unknown): Uint8Array {
+  const bytes: number[] = []
+  encodeValue(value, bytes, '/')
+  return Uint8Array.from(bytes)
+}
+
+function encodeValue(value: unknown, bytes: number[], path: string): void {
+  if (value === null) {
+    bytes.push(0xf6)
+    return
+  }
+  if (typeof value === 'boolean') {
+    bytes.push(value ? 0xf5 : 0xf4)
+    return
+  }
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value)) throw new TypeError(`plan digest input at ${path} must be a safe integer, got ${String(value)}`)
+    if (value >= 0) encodeHead(0, value, bytes)
+    else encodeHead(1, -1 - value, bytes)
+    return
+  }
+  if (typeof value === 'string') {
+    encodeText(value, bytes, path)
+    return
+  }
+  if (Array.isArray(value)) {
+    encodeHead(4, value.length, bytes)
+    for (const [index, element] of value.entries()) encodeValue(element, bytes, child(path, String(index)))
+    return
+  }
+  if (isPlainObject(value)) {
+    encodeMap(value, bytes, path)
+    return
+  }
+  throw new TypeError(`plan digest input at ${path} must be null, a boolean, a safe integer, a string, an array, or a plain object, got ${describe(value)}`)
+}
+
+function encodeMap(value: Record<string, unknown>, bytes: number[], path: string): void {
+  const entries: { key: number[]; element: number[] }[] = []
+  for (const [key, element] of Object.entries(value)) {
+    if (element === undefined) continue
+    const keyBytes: number[] = []
+    encodeText(key, keyBytes, child(path, key))
+    const elementBytes: number[] = []
+    encodeValue(element, elementBytes, child(path, key))
+    entries.push({ key: keyBytes, element: elementBytes })
+  }
+  entries.sort((left, right) => compareBytes(left.key, right.key))
+  encodeHead(5, entries.length, bytes)
+  for (const entry of entries) {
+    for (const byte of entry.key) bytes.push(byte)
+    for (const byte of entry.element) bytes.push(byte)
+  }
+}
+
+function encodeText(value: string, bytes: number[], path: string): void {
+  if (LONE_SURROGATE.test(value)) throw new TypeError(`plan digest input at ${path} contains an unpaired surrogate`)
+  const encoded = UTF8.encode(value)
+  encodeHead(3, encoded.length, bytes)
+  for (const byte of encoded) bytes.push(byte)
+}
+
+function encodeHead(major: number, argument: number, bytes: number[]): void {
+  const type = major << 5
+  if (argument < 24) {
+    bytes.push(type | argument)
+  } else if (argument < 0x100) {
+    bytes.push(type | 24, argument)
+  } else if (argument < 0x10000) {
+    bytes.push(type | 25, argument >>> 8, argument & 0xff)
+  } else if (argument < 0x100000000) {
+    bytes.push(type | 26, (argument >>> 24) & 0xff, (argument >>> 16) & 0xff, (argument >>> 8) & 0xff, argument & 0xff)
+  } else {
+    const high = Math.floor(argument / 0x100000000)
+    const low = argument % 0x100000000
+    bytes.push(type | 27, (high >>> 24) & 0xff, (high >>> 16) & 0xff, (high >>> 8) & 0xff, high & 0xff, (low >>> 24) & 0xff, (low >>> 16) & 0xff, (low >>> 8) & 0xff, low & 0xff)
+  }
+}
+
+function compareBytes(left: readonly number[], right: readonly number[]): number {
+  const length = Math.min(left.length, right.length)
+  for (let index = 0; index < length; index += 1) {
+    const delta = left[index]! - right[index]!
+    if (delta !== 0) return delta
+  }
+  return left.length - right.length
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) return false
+  const prototype: unknown = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function describe(value: unknown): string {
+  if (typeof value !== 'object' || value === null) return typeof value
+  const name: unknown = Object.getPrototypeOf(value)?.constructor?.name
+  return typeof name === 'string' && name !== '' ? `a non-plain ${name} object` : 'a non-plain object'
+}
+
+function child(path: string, segment: string): string {
+  return path === '/' ? `/${segment}` : `${path}/${segment}`
+}
+
+const SHA256_INITIAL = Uint32Array.of(
+  0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+)
+
+const SHA256_ROUND = Uint32Array.of(
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+)
+
+/** Pure SHA-256 (FIPS 180-4) over the input bytes, as 64 lowercase hex digits. Keeps the package free of platform crypto so neutral-platform builds stay dependency-free. */
+export function sha256Hex(input: Uint8Array): string {
+  const padded = new Uint8Array((((input.length + 8) >> 6) + 1) * 64)
+  padded.set(input)
+  padded[input.length] = 0x80
+  const view = new DataView(padded.buffer)
+  view.setUint32(padded.length - 8, Math.floor(input.length / 0x20000000))
+  view.setUint32(padded.length - 4, (input.length << 3) >>> 0)
+  const state = Uint32Array.from(SHA256_INITIAL)
+  const schedule = new Uint32Array(64)
+  for (let offset = 0; offset < padded.length; offset += 64) {
+    for (let index = 0; index < 16; index += 1) schedule[index] = view.getUint32(offset + index * 4)
+    for (let index = 16; index < 64; index += 1) {
+      const early = schedule[index - 15]!
+      const late = schedule[index - 2]!
+      const sigma0 = rotr(early, 7) ^ rotr(early, 18) ^ (early >>> 3)
+      const sigma1 = rotr(late, 17) ^ rotr(late, 19) ^ (late >>> 10)
+      schedule[index] = (schedule[index - 16]! + sigma0 + schedule[index - 7]! + sigma1) >>> 0
+    }
+    let a = state[0]!
+    let b = state[1]!
+    let c = state[2]!
+    let d = state[3]!
+    let e = state[4]!
+    let f = state[5]!
+    let g = state[6]!
+    let h = state[7]!
+    for (let index = 0; index < 64; index += 1) {
+      const temp1 = (h + (rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25)) + ((e & f) ^ (~e & g)) + SHA256_ROUND[index]! + schedule[index]!) >>> 0
+      const temp2 = ((rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22)) + ((a & b) ^ (a & c) ^ (b & c))) >>> 0
+      h = g
+      g = f
+      f = e
+      e = (d + temp1) >>> 0
+      d = c
+      c = b
+      b = a
+      a = (temp1 + temp2) >>> 0
+    }
+    state[0] = (state[0]! + a) >>> 0
+    state[1] = (state[1]! + b) >>> 0
+    state[2] = (state[2]! + c) >>> 0
+    state[3] = (state[3]! + d) >>> 0
+    state[4] = (state[4]! + e) >>> 0
+    state[5] = (state[5]! + f) >>> 0
+    state[6] = (state[6]! + g) >>> 0
+    state[7] = (state[7]! + h) >>> 0
+  }
+  return [...state].map(word => word.toString(16).padStart(8, '0')).join('')
+}
+
+function rotr(value: number, count: number): number {
+  return ((value >>> count) | (value << (32 - count))) >>> 0
+}

--- a/packages/connection/src/model.ts
+++ b/packages/connection/src/model.ts
@@ -52,6 +52,7 @@ export interface ConnectionPlan {
   readonly kind: 'ConnectionAgreement'
   readonly connectionId: string
   readonly revision: number
+  /** SHA-256 over the deterministic CBOR encoding of this agreement without `digest`, as `sha256:` plus 64 lowercase hex digits. */
   readonly digest: string
   readonly offers: readonly {
     readonly endpoint: ConnectionEndpointReference

--- a/packages/connection/src/resolve.ts
+++ b/packages/connection/src/resolve.ts
@@ -1,4 +1,4 @@
-import type { ProtocolIssue } from '@dsh-std/core'
+import type { NegotiatedProtocol, ProtocolIssue } from '@dsh-std/core'
 import {
   CONNECTION_API_VERSION,
   freezeEndpoint,
@@ -12,7 +12,7 @@ import {
   type EndpointOffer,
   type ResolveConnectionOptions,
 } from './model.js'
-import { planDigest } from './digest.js'
+import { compareDeterministicCbor, planDigest } from './digest.js'
 import { isCapabilityAgreement } from './rpc.js'
 
 /**
@@ -22,7 +22,8 @@ import { isCapabilityAgreement } from './rpc.js'
  * Offer order is part of the plan identity: `left` MUST be the coordinator (initiator) offer and
  * `right` the responder offer, and both parties MUST resolve with the offers in that same order.
  * Declaration order feeds negotiation issue paths and the digest input, so swapped offers produce
- * a plan whose digest does not compare equal.
+ * a plan whose digest does not compare equal. Digest-bearing result arrays are normalized by the
+ * bytewise order of their deterministic CBOR encodings rather than host locale collation.
  */
 export function resolveConnection(left: EndpointOffer, right: EndpointOffer, options: ResolveConnectionOptions): ConnectionPlan {
   validateEndpointOffer(left)
@@ -39,8 +40,9 @@ export function resolveConnection(left: EndpointOffer, right: EndpointOffer, opt
     ...(options.policy === undefined ? {} : { protocol: options.policy }),
   })
   const report = options.protocols.negotiate([...left.declarations, ...right.declarations], policy)
+  const protocols = normalizeProtocols(report.protocols)
   const bindings: CapabilityBinding[] = []
-  for (const protocol of report.protocols) {
+  for (const protocol of protocols) {
     if (!isCapabilityAgreement(protocol.agreement)) continue
     for (const draft of protocol.agreement.bindings) {
       const consumer = owner.get(draft.consumer)
@@ -55,12 +57,9 @@ export function resolveConnection(left: EndpointOffer, right: EndpointOffer, opt
       }))
     }
   }
-  bindings.sort((a, b) => a.consumer.participantId.localeCompare(b.consumer.participantId)
-    || a.requirement.apiVersion.localeCompare(b.requirement.apiVersion)
-    || a.requirement.kind.localeCompare(b.requirement.kind)
-    || a.provider.participantId.localeCompare(b.provider.participantId))
+  bindings.sort((left, right) => compareDeterministicCbor(bindingSortKey(left), bindingSortKey(right)))
   const numbered = bindings.map((binding, index) => Object.freeze({ ...binding, bindingId: `binding-${String(index + 1)}` }))
-  const issues = Object.freeze(report.issues.map(row => connectionIssue(row, owner)))
+  const issues = Object.freeze(report.issues.map(row => connectionIssue(row, owner)).sort(compareDeterministicCbor))
   const coordinates = Object.freeze([
     Object.freeze({ endpoint: freezeEndpoint(left.endpoint), revision: left.revision }),
     Object.freeze({ endpoint: freezeEndpoint(right.endpoint), revision: right.revision }),
@@ -72,11 +71,29 @@ export function resolveConnection(left: EndpointOffer, right: EndpointOffer, opt
     revision: options.revision,
     offers: coordinates,
     compatible: report.compatible,
-    protocols: report.protocols,
+    protocols,
     bindings: Object.freeze(numbered),
     issues,
   }
   return Object.freeze({ ...agreement, digest: planDigest(agreement) })
+}
+
+function bindingSortKey(binding: CapabilityBinding): Omit<CapabilityBinding, 'bindingId'> {
+  const { bindingId: _bindingId, ...key } = binding
+  return key
+}
+
+function normalizeProtocols(protocols: readonly NegotiatedProtocol[]): readonly NegotiatedProtocol[] {
+  const normalized = protocols.map(protocol => Object.freeze({
+    ...protocol,
+    participants: Object.freeze([...protocol.participants].sort(compareDeterministicCbor)),
+    issues: Object.freeze([...protocol.issues].sort(compareDeterministicCbor)),
+  }))
+  normalized.sort((left, right) => compareDeterministicCbor(
+    [left.apiVersion, left.kind],
+    [right.apiVersion, right.kind],
+  ))
+  return Object.freeze(normalized)
 }
 
 function participantOwners(left: EndpointOffer, right: EndpointOffer): Map<string, CapabilityParticipant> {

--- a/packages/connection/src/resolve.ts
+++ b/packages/connection/src/resolve.ts
@@ -12,8 +12,18 @@ import {
   type EndpointOffer,
   type ResolveConnectionOptions,
 } from './model.js'
+import { planDigest } from './digest.js'
 import { isCapabilityAgreement } from './rpc.js'
 
+/**
+ * Resolves two endpoint offers into a connection plan whose digest both parties recompute and
+ * compare before accepting the plan.
+ *
+ * Offer order is part of the plan identity: `left` MUST be the coordinator (initiator) offer and
+ * `right` the responder offer, and both parties MUST resolve with the offers in that same order.
+ * Declaration order feeds negotiation issue paths and the digest input, so swapped offers produce
+ * a plan whose digest does not compare equal.
+ */
 export function resolveConnection(left: EndpointOffer, right: EndpointOffer, options: ResolveConnectionOptions): ConnectionPlan {
   validateEndpointOffer(left)
   validateEndpointOffer(right)
@@ -55,34 +65,18 @@ export function resolveConnection(left: EndpointOffer, right: EndpointOffer, opt
     Object.freeze({ endpoint: freezeEndpoint(left.endpoint), revision: left.revision }),
     Object.freeze({ endpoint: freezeEndpoint(right.endpoint), revision: right.revision }),
   ])
-  const digest = planDigest({ connectionId: options.connectionId, revision: options.revision, offers: coordinates, protocols: report.protocols })
-  return Object.freeze({
+  const agreement: Omit<ConnectionPlan, 'digest'> = {
     apiVersion: CONNECTION_API_VERSION,
     kind: 'ConnectionAgreement',
     connectionId: options.connectionId,
     revision: options.revision,
-    digest,
     offers: coordinates,
     compatible: report.compatible,
     protocols: report.protocols,
     bindings: Object.freeze(numbered),
     issues,
-  })
-}
-
-function planDigest(value: unknown): string {
-  const input = canonical(value)
-  let hash = 2166136261
-  for (let index = 0; index < input.length; index += 1) hash = Math.imul(hash ^ input.charCodeAt(index), 16777619)
-  return `fnv1a32:${(hash >>> 0).toString(16).padStart(8, '0')}`
-}
-
-function canonical(value: unknown): string {
-  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`
-  if (typeof value === 'object' && value !== null) {
-    return `{${Object.entries(value).sort(([a], [b]) => a.localeCompare(b)).map(([key, item]) => `${JSON.stringify(key)}:${canonical(item)}`).join(',')}}`
   }
-  return JSON.stringify(value)
+  return Object.freeze({ ...agreement, digest: planDigest(agreement) })
 }
 
 function participantOwners(left: EndpointOffer, right: EndpointOffer): Map<string, CapabilityParticipant> {

--- a/packages/connection/tests/connection.spec.ts
+++ b/packages/connection/tests/connection.spec.ts
@@ -53,7 +53,7 @@ describe('@dsh-std/connection', () => {
     })
     expect(plan).toMatchObject({
       kind: 'ConnectionAgreement', compatible: true,
-      digest: expect.stringMatching(/^fnv1a32:/),
+      digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
       protocols: [{ kind: 'Echo', agreement: { kind: 'CapabilityBindings' } }],
       bindings: [{
         consumer: { participantId: 'client/consumer' },

--- a/packages/connection/tests/digest.spec.ts
+++ b/packages/connection/tests/digest.spec.ts
@@ -1,0 +1,149 @@
+import { createHash, randomBytes } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import { ProtocolCatalog, defineProtocolDeclaration } from '@dsh-std/core'
+import { StandardEndpointRuntime, defineCapabilityProtocol, resolveConnection } from '../src/index.js'
+import { deterministicCbor, planDigest, sha256Hex } from '../src/digest.js'
+
+const service = Object.freeze({ apiVersion: 'example.dsh/v1alpha1', kind: 'Echo' })
+
+function protocols() {
+  const catalog = new ProtocolCatalog({ name: 'digest-test', version: '1.0.0' })
+  catalog.register(defineCapabilityProtocol(service))
+  return catalog
+}
+
+function offers() {
+  const left = new StandardEndpointRuntime({ id: 'client', instanceId: 'client-1' })
+  left.register({ declaration: defineProtocolDeclaration({
+    participant: { id: 'client/consumer' }, requires: [service],
+  }) })
+  const right = new StandardEndpointRuntime({ id: 'host', instanceId: 'host-1' })
+  right.register({ declaration: defineProtocolDeclaration({
+    participant: { id: 'host/provider' }, supports: [service],
+  }) })
+  return { left: left.offer, right: right.offer }
+}
+
+function hex(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('hex')
+}
+
+describe('plan digest', () => {
+  it('hashes the digest-stripped agreement with SHA-256 over deterministic CBOR', () => {
+    const { left, right } = offers()
+    const plan = resolveConnection(left, right, { connectionId: 'connection-1', revision: 1, protocols: protocols() })
+    expect(plan.digest).toMatch(/^sha256:[0-9a-f]{64}$/)
+    const { digest, ...stripped } = plan
+    expect(planDigest(stripped)).toBe(digest)
+    expect(digest).toBe(`sha256:${createHash('sha256').update(deterministicCbor(stripped)).digest('hex')}`)
+  })
+
+  it('is stable across recomputation and across independently constructed inputs in the same order', () => {
+    const first = offers()
+    const second = offers()
+    const coordinates = { connectionId: 'connection-1', revision: 1 }
+    const initiator = resolveConnection(first.left, first.right, { ...coordinates, protocols: protocols() })
+    const responder = resolveConnection(second.left, second.right, { ...coordinates, protocols: protocols() })
+    expect(responder.digest).toBe(initiator.digest)
+    expect(resolveConnection(first.left, first.right, { ...coordinates, protocols: protocols() }).digest).toBe(initiator.digest)
+  })
+
+  it('covers the full agreement: plans differing only in negotiation outcome differ in digest', () => {
+    const { left, right } = offers()
+    const ambiguous = new StandardEndpointRuntime({ id: 'host', instanceId: 'host-1' })
+    ambiguous.register({ declaration: defineProtocolDeclaration({
+      participant: { id: 'host/provider' }, supports: [service],
+    }) })
+    ambiguous.register({ declaration: defineProtocolDeclaration({
+      participant: { id: 'host/second-provider' }, supports: [service],
+    }) })
+    const clean = resolveConnection(left, right, { connectionId: 'connection-1', revision: 1, protocols: protocols() })
+    const conflicted = resolveConnection(left, ambiguous.offer, { connectionId: 'connection-1', revision: 1, protocols: protocols() })
+    expect(conflicted.compatible).toBe(false)
+    expect(conflicted.digest).not.toBe(clean.digest)
+  })
+})
+
+describe('deterministic CBOR subset', () => {
+  it('matches RFC 8949 encodings for supported values', () => {
+    const vectors: readonly [unknown, string][] = [
+      [0, '00'],
+      [23, '17'],
+      [24, '1818'],
+      [255, '18ff'],
+      [256, '190100'],
+      [65536, '1a00010000'],
+      [4294967296, '1b0000000100000000'],
+      [Number.MAX_SAFE_INTEGER, '1b001fffffffffffff'],
+      [-1, '20'],
+      [-24, '37'],
+      [-25, '3818'],
+      [-4294967297, '3b0000000100000000'],
+      [Number.MIN_SAFE_INTEGER, '3b001ffffffffffffe'],
+      [true, 'f5'],
+      [false, 'f4'],
+      [null, 'f6'],
+      ['', '60'],
+      ['IETF', '6449455446'],
+      ['ü', '62c3bc'],
+      ['水', '63e6b0b4'],
+      ['\u{10151}', '64f0908591'],
+      [[], '80'],
+      [[1, [2, 3]], '8201820203'],
+      [{}, 'a0'],
+      [{ a: 1, b: [2, 3] }, 'a26161016162820203'],
+    ]
+    for (const [value, expected] of vectors) expect(hex(deterministicCbor(value)), JSON.stringify(value)).toBe(expected)
+  })
+
+  it('sorts map keys bytewise by their encodings, shorter keys first', () => {
+    expect(hex(deterministicCbor({ aa: 1, b: 2 }))).toBe('a2616202626161' + '01')
+  })
+
+  it('drops undefined-valued map properties the way a JSON wire would', () => {
+    expect(hex(deterministicCbor({ spec: undefined }))).toBe(hex(deterministicCbor({})))
+    expect(hex(deterministicCbor({ kind: 'Echo', spec: undefined }))).toBe(hex(deterministicCbor({ kind: 'Echo' })))
+  })
+
+  it('rejects undefined array elements instead of colliding with the empty array', () => {
+    expect(hex(deterministicCbor([]))).toBe('80')
+    expect(() => deterministicCbor([undefined])).toThrow(TypeError)
+    expect(() => deterministicCbor([undefined])).toThrow('/0')
+  })
+
+  it('rejects values outside the subset with the offending path', () => {
+    expect(() => deterministicCbor(undefined)).toThrow(TypeError)
+    expect(() => deterministicCbor(1.5)).toThrow('must be a safe integer')
+    expect(() => deterministicCbor(Number.NaN)).toThrow(TypeError)
+    expect(() => deterministicCbor(Number.MAX_SAFE_INTEGER + 1)).toThrow(TypeError)
+    expect(() => deterministicCbor({ nested: { value: 2 ** 60 } })).toThrow('/nested/value')
+    expect(() => deterministicCbor(new Date(0))).toThrow('non-plain Date object')
+    expect(() => deterministicCbor(new Map())).toThrow(TypeError)
+    expect(() => deterministicCbor(10n)).toThrow(TypeError)
+    expect(() => deterministicCbor('\ud800')).toThrow('unpaired surrogate')
+    expect(() => deterministicCbor({ text: 'ok\udfff' })).toThrow('/text')
+  })
+
+  it('accepts null-prototype objects as maps', () => {
+    const bare: Record<string, unknown> = Object.create(null) as Record<string, unknown>
+    bare.a = 1
+    expect(hex(deterministicCbor(bare))).toBe(hex(deterministicCbor({ a: 1 })))
+  })
+})
+
+describe('pure SHA-256', () => {
+  it('matches the FIPS 180-4 test vectors', () => {
+    expect(sha256Hex(new Uint8Array(0))).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+    expect(sha256Hex(new TextEncoder().encode('abc'))).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
+    expect(sha256Hex(new TextEncoder().encode('abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq')))
+      .toBe('248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1')
+  })
+
+  it('matches node:crypto across block-boundary and random lengths', () => {
+    const lengths = [0, 1, 31, 55, 56, 57, 63, 64, 65, 127, 128, 1000, ...Array.from({ length: 32 }, () => Math.floor(Math.random() * 2048))]
+    for (const length of lengths) {
+      const input = new Uint8Array(randomBytes(length))
+      expect(sha256Hex(input), `length ${String(length)}`).toBe(createHash('sha256').update(input).digest('hex'))
+    }
+  })
+})

--- a/packages/connection/tests/digest.spec.ts
+++ b/packages/connection/tests/digest.spec.ts
@@ -2,7 +2,7 @@ import { createHash, randomBytes } from 'node:crypto'
 import { describe, expect, it } from 'vitest'
 import { ProtocolCatalog, defineProtocolDeclaration } from '@dsh-std/core'
 import { StandardEndpointRuntime, defineCapabilityProtocol, resolveConnection } from '../src/index.js'
-import { deterministicCbor, planDigest, sha256Hex } from '../src/digest.js'
+import { compareDeterministicCbor, deterministicCbor, planDigest, sha256Hex } from '../src/digest.js'
 
 const service = Object.freeze({ apiVersion: 'example.dsh/v1alpha1', kind: 'Echo' })
 
@@ -48,6 +48,16 @@ describe('plan digest', () => {
     expect(resolveConnection(first.left, first.right, { ...coordinates, protocols: protocols() }).digest).toBe(initiator.digest)
   })
 
+  it('treats the coordinator-responder offer tuple as part of plan identity', () => {
+    const { left, right } = offers()
+    const coordinates = { connectionId: 'connection-1', revision: 1 }
+    const forward = resolveConnection(left, right, { ...coordinates, protocols: protocols() })
+    const reversed = resolveConnection(right, left, { ...coordinates, protocols: protocols() })
+    expect(forward.offers.map(offer => offer.endpoint.instanceId)).toEqual(['client-1', 'host-1'])
+    expect(reversed.offers.map(offer => offer.endpoint.instanceId)).toEqual(['host-1', 'client-1'])
+    expect(reversed.digest).not.toBe(forward.digest)
+  })
+
   it('covers the full agreement: plans differing only in negotiation outcome differ in digest', () => {
     const { left, right } = offers()
     const ambiguous = new StandardEndpointRuntime({ id: 'host', instanceId: 'host-1' })
@@ -62,6 +72,44 @@ describe('plan digest', () => {
     expect(conflicted.compatible).toBe(false)
     expect(conflicted.digest).not.toBe(clean.digest)
   })
+
+  it('normalizes bindings by deterministic CBOR order rather than locale collation', () => {
+    const coordinator = new StandardEndpointRuntime({ id: 'client', instanceId: 'client-1' })
+    for (const participant of ['ä', 'z']) coordinator.register({ declaration: defineProtocolDeclaration({
+      participant: { id: participant }, requires: [service],
+    }) })
+    const responder = new StandardEndpointRuntime({ id: 'host', instanceId: 'host-1' })
+    responder.register({ declaration: defineProtocolDeclaration({
+      participant: { id: 'provider' }, supports: [service],
+    }) })
+    const plan = resolveConnection(coordinator.offer, responder.offer, {
+      connectionId: 'connection-1', revision: 1, protocols: protocols(),
+    })
+    expect(compareDeterministicCbor('z', 'ä')).toBeLessThan(0)
+    expect(plan.bindings.map(binding => binding.consumer.participantId)).toEqual(['z', 'ä'])
+    expect(plan.bindings.map(binding => binding.bindingId)).toEqual(['binding-1', 'binding-2'])
+  })
+
+  it('normalizes protocols by deterministic CBOR coordinate order', () => {
+    const services = [
+      Object.freeze({ apiVersion: 'a-a/v1', kind: 'Echo' }),
+      Object.freeze({ apiVersion: 'aa/v1', kind: 'Echo' }),
+    ] as const
+    const catalog = new ProtocolCatalog({ name: 'digest-order-test', version: '1.0.0' })
+    for (const reference of services) catalog.register(defineCapabilityProtocol(reference))
+    const coordinator = new StandardEndpointRuntime({ id: 'client', instanceId: 'client-1' })
+    coordinator.register({ declaration: defineProtocolDeclaration({
+      participant: { id: 'consumer' }, requires: services,
+    }) })
+    const responder = new StandardEndpointRuntime({ id: 'host', instanceId: 'host-1' })
+    responder.register({ declaration: defineProtocolDeclaration({
+      participant: { id: 'provider' }, supports: services,
+    }) })
+    const plan = resolveConnection(coordinator.offer, responder.offer, {
+      connectionId: 'connection-1', revision: 1, protocols: catalog,
+    })
+    expect(plan.protocols.map(protocol => protocol.apiVersion)).toEqual(['aa/v1', 'a-a/v1'])
+  })
 })
 
 describe('deterministic CBOR subset', () => {
@@ -75,14 +123,11 @@ describe('deterministic CBOR subset', () => {
       [65536, '1a00010000'],
       [4294967296, '1b0000000100000000'],
       [Number.MAX_SAFE_INTEGER, '1b001fffffffffffff'],
-      [-1, '20'],
-      [-24, '37'],
-      [-25, '3818'],
-      [-4294967297, '3b0000000100000000'],
-      [Number.MIN_SAFE_INTEGER, '3b001ffffffffffffe'],
       [true, 'f5'],
       [false, 'f4'],
       [null, 'f6'],
+      [new Uint8Array(), '40'],
+      [Uint8Array.from([1, 2, 3, 4]), '4401020304'],
       ['', '60'],
       ['IETF', '6449455446'],
       ['ü', '62c3bc'],
@@ -96,7 +141,7 @@ describe('deterministic CBOR subset', () => {
     for (const [value, expected] of vectors) expect(hex(deterministicCbor(value)), JSON.stringify(value)).toBe(expected)
   })
 
-  it('sorts map keys bytewise by their encodings, shorter keys first', () => {
+  it('sorts map keys bytewise by their deterministic encodings', () => {
     expect(hex(deterministicCbor({ aa: 1, b: 2 }))).toBe('a2616202626161' + '01')
   })
 
@@ -113,7 +158,9 @@ describe('deterministic CBOR subset', () => {
 
   it('rejects values outside the subset with the offending path', () => {
     expect(() => deterministicCbor(undefined)).toThrow(TypeError)
-    expect(() => deterministicCbor(1.5)).toThrow('must be a safe integer')
+    expect(() => deterministicCbor(-1)).toThrow('must be a non-negative safe integer')
+    expect(() => deterministicCbor({ nested: -1 })).toThrow('/nested')
+    expect(() => deterministicCbor(1.5)).toThrow('must be a non-negative safe integer')
     expect(() => deterministicCbor(Number.NaN)).toThrow(TypeError)
     expect(() => deterministicCbor(Number.MAX_SAFE_INTEGER + 1)).toThrow(TypeError)
     expect(() => deterministicCbor({ nested: { value: 2 ** 60 } })).toThrow('/nested/value')
@@ -122,6 +169,16 @@ describe('deterministic CBOR subset', () => {
     expect(() => deterministicCbor(10n)).toThrow(TypeError)
     expect(() => deterministicCbor('\ud800')).toThrow('unpaired surrogate')
     expect(() => deterministicCbor({ text: 'ok\udfff' })).toThrow('/text')
+  })
+
+  it('rejects cyclic arrays and maps with the offending path', () => {
+    const array: unknown[] = []
+    array.push(array)
+    const map: Record<string, unknown> = {}
+    map.self = map
+    expect(() => deterministicCbor(array)).toThrow('/0')
+    expect(() => deterministicCbor(array)).toThrow('must not contain a cycle')
+    expect(() => deterministicCbor(map)).toThrow('/self')
   })
 
   it('accepts null-prototype objects as maps', () => {

--- a/packages/core/tests/core.spec.ts
+++ b/packages/core/tests/core.spec.ts
@@ -4,6 +4,7 @@ import {
   defineProtocolDeclaration,
   parseApiVersion,
   protocolFamilyKey,
+  validateApiReference,
 } from '../src/index.js'
 
 function catalog() {
@@ -180,5 +181,16 @@ describe('@dsh-std/core', () => {
     expect(parseApiVersion('connection.dsh/v2beta3')).toEqual({
       group: 'connection.dsh', major: 2, stability: 'beta', revision: 3,
     })
+  })
+
+  it('requires kind to be an ASCII identifier beginning with an uppercase letter', () => {
+    for (const kind of ['Z', 'Z2', 'ConnectionService']) {
+      expect(() => validateApiReference({ apiVersion: 'example.dsh/v1alpha1', kind })).not.toThrow()
+    }
+    for (const kind of ['', 'z', 'ä', 'Ä', 'A-B', 'A_B']) {
+      expect(() => validateApiReference({ apiVersion: 'example.dsh/v1alpha1', kind })).toThrow(
+        /protocol reference\.kind is invalid/,
+      )
+    }
   })
 })


### PR DESCRIPTION
## 问题

`packages/connection/src/resolve.ts` 的 plan digest 是连接双方必须各自独立计算并比较相等后才接受 plan 的比较器（docs/proposals/endpoint-connection.zh.md 第 340、400 行；docs/proposals/connection-wire.zh.md 第 159–170 行）。基于 bb194ad，现实现有四个缺陷：

1. **算法偏离提案且强度不足**（旧 `resolve.ts:73-78`）：使用 FNV-1a 32 位哈希手工拼接的 canonical 字符串。connection-wire.zh.md 第 46 行锁定的是对去除 `digest` 字段的 agreement 的 deterministic CBOR bytes 计算 SHA-256。32 位对一个用于互相比对的摘要而言可轻易构造碰撞。
2. **canonical 形式产生非法编码与真实碰撞**（旧 `resolve.ts:80-86`）：`JSON.stringify(undefined)` 返回 `undefined`，值为 `undefined` 的属性被渲染成字面文本 `undefined`——而 core 的 negotiate 对没有 `spec` 的 requirement 恒物化 `spec` 属性（`packages/core/src/negotiation.ts:152-154`，`defineCapabilityProtocol` 的默认校验器是恒等函数），所以这不是边角情况而是常规路径。`[undefined]` 经 `Array.prototype.join` 与 `[]` 得到相同 canonical 串，是真实碰撞类。非 plain 对象被静默错编。
3. **digest 输入不完整**（旧 `resolve.ts:58`）：只覆盖 `{connectionId, revision, offers, protocols}`，`compatible`、`bindings`、`issues`、`apiVersion`、`kind` 均不在内；提案要求对去 `digest` 的完整 agreement 计算。
4. **未文档化 offer 顺序约定**：issue 的 `path` 内嵌 declaration 下标（`/declarations/<i>/...`），该下标取决于 `[...left.declarations, ...right.declarations]` 的拼接顺序。双方若各以自己的 offer 为先，会得到不同的 digest，永远无法比对相等。

## 修复

- 新增内部模块 `packages/connection/src/digest.ts`（零依赖、platform-neutral，不进入公共导出）：RFC 8949 core deterministic 子集的 CBOR 编码器 + 纯 TS SHA-256（FIPS 180-4）。
- `planDigest` 改为：对去除 `digest` 字段的完整 agreement（`Omit<ConnectionPlan, 'digest'>`，即 `{apiVersion, kind, connectionId, revision, offers, compatible, protocols, bindings, issues}`）的 deterministic CBOR bytes 计算 SHA-256，渲染为 `sha256:` + 64 位小写 hex。
- 编码子集：safe integer（最短编码）、text string（definite length，拒绝未配对 surrogate）、array、map（text key 按编码字节序排序）、boolean、null。**先剥离 map 中值为 `undefined` 的自有属性**（与 `JSON.stringify` 对对象的投影一致，即该 agreement 走 JSON wire 时的形态），其余位置的 `undefined`（数组元素、根值）、非整数或超出 safe 范围的 number、非 plain 对象一律抛出带路径的 `TypeError`，不再静默碰撞。
- `resolveConnection` JSDoc 文档化顺序约定：`left` 必须是 coordinator（发起方）offer，双方必须以相同顺序调用，digest 才可比对相等。
- 更新 `packages/connection/CHANGELOG.md`；`packages/connection/tests/connection.spec.ts` 的 `/^fnv1a32:/` 断言改为 `/^sha256:[0-9a-f]{64}$/`。`@dsh-std/manifest` 与 `@dsh-std/composition` 中的 fnv1a32 是各自本地摘要（manifest 内容摘要、composition selection revision），不参与跨方比较，未改动。

## 与 connection-wire.zh.md 的偏差，请维护者裁决

1. **digest 字符串表示**：提案只规定计算 SHA-256，未规定字符串格式。本 PR 采用 `sha256:` + 64 位小写 hex，与 `@dsh-std/manifest` artifact digest 的 `^sha256:[a-f0-9]{64}$` 格式一致。
2. **undefined 剥离规则**：提案禁止 frame 中出现 undefined；但内存中的 agreement 对象因 core 恒物化 `spec: undefined` 而必然含有 undefined 值属性。本 PR 将"剥离 undefined 值的 map 属性再编码"定为投影规则（与 JSON wire 投影一致）。若维护者倾向由 core 侧改为不物化该属性，剥离规则可以收紧为一律拒绝。
3. **负整数**：提案 frame 子集将 integer 限定在 `0..2^53-1`。当前 digest 输入没有负值；本 PR 编码器额外支持 safe 范围内的负整数（major type 1），使其与 RFC 8949 核心确定性子集对齐。可按需收紧为仅非负。
4. **顺序约定的层级**：本 PR 只以 JSDoc 文档化 `left` = coordinator，未消除 issue `path` 对 declaration 下标的依赖。顺序无关的 canonicalization 是更大的协议改动，不在本 PR 范围。

## 测试

新增 `packages/connection/tests/digest.spec.ts`：

- digest 等于对返回 plan 去 `digest` 后重算的值，并与 `node:crypto` 的 SHA-256 交叉验证；
- 相同顺序下独立构造输入两次计算相等，重复计算稳定；
- 仅协商结果不同（compatible/issues/bindings）的 plan digest 不同，验证输入覆盖完整 agreement；
- RFC 8949 编码向量（含 8 字节整数、负整数、UTF-8、astral 码点）与 map key 字节序排序（短 key 在前，非 localeCompare 序）；
- `{spec: undefined}` 与 `{}` 编码相同；`[undefined]` 抛 `TypeError`（原碰撞类现为拒绝）；float、NaN、非 safe 整数、bigint、Date、Map、未配对 surrogate 均抛带路径的 `TypeError`；
- 纯 TS SHA-256 对 FIPS 180-4 向量及跨块边界长度、随机输入与 `node:crypto` 一致。

`pnpm check`（changelog gate + 全部包 build/typecheck + 测试）全绿。

## 背景

这是外部 carrier 实现的前置：一个 ibuki peer wire 需要在自有 carrier 上实现 plan-accept 的 digest 比较，前提是双方能对同一 agreement 独立复算出同一 digest。本 PR 只修 digest 的可复现性与健全性，不涉及 wire framing 或其他 frame 类型。
